### PR TITLE
wireless-config: fix "use of uninitialized value" warning

### DIFF
--- a/scripts/wireless-config.pl
+++ b/scripts/wireless-config.pl
@@ -219,8 +219,9 @@ sub check_config {
 	next unless $ophy;
 	next if ($ophy ne $phy);
 
+	my $ossid = $config->returnValue("$intf ssid");
 	die "$wlan: Duplicate SSID on same physical device: $phy\n"
-	    if ($ssid eq $config->returnValue("$intf ssid"));
+	    if (defined($ssid) && defined($ossid) && $ssid eq $ossid);
 
 	my $ochan = $config->returnValue('channel');
 	die "$wlan: Duplicate channel on same physical device: $phy\n"


### PR DESCRIPTION
When configuring multiple wireless interfaces on the same physical device,
if one of those interfaces is set to type "monitor" and the other to type
"access-point", committing this configuration generates a "use of
uninitialized value" warning.  While this doesn't prevent the above
configuration from committing, it looks better with a clean commit.
