### PR TITLE
BUGFIX: WPA2 enabled access points do not work

### DIFF
--- a/scripts/wireless-hostapd.pl
+++ b/scripts/wireless-hostapd.pl
@@ -147,7 +147,7 @@ if ( $config->exists('wep') ) {
     print "wpa=", $wpa_mode{$config->returnValue('mode')}, "\n";
 
     my @cipher = $config->returnValues('cipher');
-    @cipher = ( 'CCMP', 'TKIP' )
+    @cipher = ( 'CCMP' )
 	unless (@cipher);
     print "wpa_pairwise=",join(' ',@cipher), "\n";
 


### PR DESCRIPTION
  This patches a functional flaw when setting up WPA2 Access Points.
  Only CCMP may be active in that case. By default, CCMP and TKIP
  are configured.
  Since this parameter is optional, one might end up with a
  non-functional Wifi card if CCMP was not configured explicitly.
  Therefore, I suggest to set the default to CCMP only.

Best regards!
