### PR TITLE
wireless-hostapd: set default ciphers used based on the wpa mode

### DIFF
--- a/scripts/wireless-hostapd.pl
+++ b/scripts/wireless-hostapd.pl
@@ -144,12 +144,25 @@ if ( $config->exists('wep') ) {
     my $phrase = $config->returnValue('passphrase');
     my @radius = $config->listNodes('radius-server');
 
-    print "wpa=", $wpa_mode{$config->returnValue('mode')}, "\n";
+    my $wpa_type = $config->returnValue('mode');
+    print "wpa=", $wpa_mode{$wpa_type}, "\n";
 
     my @cipher = $config->returnValues('cipher');
-    @cipher = ( 'CCMP', 'TKIP' )
-	unless (@cipher);
-    print "wpa_pairwise=",join(' ',@cipher), "\n";
+
+    if ( $wpa_type eq 'wpa' ) {    
+        @cipher = ( 'TKIP', 'CCMP' )
+	    unless (@cipher);
+    } elsif ( $wpa_type eq 'both' ) {
+        @cipher = ( 'CCMP', 'TKIP' )
+            unless (@cipher);
+    }
+    if ( $wpa_type eq 'wpa2' ) {
+        @cipher = ( 'CCMP' )
+            unless (@cipher);
+        print "rsn_pairwise=",join(' ',@cipher), "\n";
+    } else {
+        print "wpa_pairwise=",join(' ',@cipher), "\n";
+    }
 
     if ($phrase) {
         print "auth_algs=1\nwpa_passphrase=$phrase\nwpa_key_mgmt=WPA-PSK\n";


### PR DESCRIPTION
Set the default ciphers used based on the WPA mode configured, as
certain wireless NICs have been reported to not function correctly
when configured with WPA2 and both CCMP and TKIP ciphers.  This sets
the default ciphers to be TKIP and CCMP when configured for WPA mode
(some WPA clients can use CCMP, most are limited to TKIP), CCMP and
TKIP when configured for both (allowing WPA and WPA2 clients, with
CCMP being suggested first to work round certain broken clients)
and finally CCMP only when configured for WPA2.  These default values
are only used if ciphers haven't been configured.

Bug #295 http://bugzilla.vyos.net/show_bug.cgi?id=295
