### PR TITLE
vyatta-wireless: add crda and wireless-regdb to dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,9 @@ Depends: vyatta-cfg (>= 0.15.33),
  vyatta-cfg-system (>= 0.19.1),
  hostapd (>= 0.6.8),
  wpasupplicant (>= 0.6.7),
- iw
+ iw,
+ crda,
+ wireless-regdb
 Description: Vyatta configuration/operational commands for 802.11 wireless
  Vyatta configuration and operational templates and scripts for 802.11 wireless
  devices and access points.


### PR DESCRIPTION
Add both the crda and wireless-regdb packages as dependencies for
vyatta-wireless.  This also needs the above packages adding to the
central VyOS repositories (from backports, Bug #311).

These two packages enable the correct regulatory domain to be set on
wireless NICs, as at the moment they will default to US no matter what
they are set to in the configuration.

Bug #315 http://bugzilla.vyos.net/show_bug.cgi?id=315
