### PR TITLE
Adjust path of 'iw' binary to match new debian location

### DIFF
--- a/scripts/show-wireless.pl
+++ b/scripts/show-wireless.pl
@@ -25,7 +25,7 @@ use Getopt::Long;
 use strict;
 use warnings;
 
-my $IW = "sudo /usr/sbin/iw";
+my $IW = "sudo /sbin/iw";
 
 sub usage {
     print <<EOF;

--- a/scripts/wireless-config.pl
+++ b/scripts/wireless-config.pl
@@ -28,7 +28,7 @@ use Vyatta::Interface;
 use strict;
 use warnings;
 
-my $IW = "/usr/sbin/iw";
+my $IW = "/sbin/iw";
 
 my %iw2type = (
     'IBSS'	=> 'adhoc',

--- a/templates-op/show/interfaces/wireless/node.tag/scan/detail/node.def
+++ b/templates-op/show/interfaces/wireless/node.tag/scan/detail/node.def
@@ -1,2 +1,2 @@
 help: Show detailed scan results
-run: sudo /usr/sbin/iw dev $4 scan
+run: sudo /sbin/iw dev $4 scan


### PR DESCRIPTION
Debian 8 jessie uses '/sbin/iw' instead of '/usr/sbin/iw'.

This fixes "T368: iw missing" and "T278: VyOS Beta, location of 'iw'
changed in debian from /usr/sbin/iw to /sbin/iw"