### PR TITLE
T452: Enable support for 5 GHz WiFi AccesPoints w/ DFS

### DIFF
--- a/scripts/wireless-config.pl
+++ b/scripts/wireless-config.pl
@@ -213,6 +213,9 @@ sub check_config {
 	    my $omac = getmac($intf);
 	    die "$wlan: Duplicate MAC address with $intf\n"
 		if (defined($omac) && $omac eq $mac);
+	    my $country = $config->returnValue('country');
+	    die ("$wlan: country reg domain must be set for access points\n")
+	            unless defined($country);
 	}
 
 	my $ophy = get_phy($intf);

--- a/scripts/wireless-hostapd.pl
+++ b/scripts/wireless-hostapd.pl
@@ -71,6 +71,10 @@ print "driver=nl80211\n";
 
 my $bridge = $config->returnValue('bridge-group bridge');
 print "bridge=$bridge\n"  if $bridge;
+if ($bridge) {
+    print "bridge=$bridge\n";
+    print "wds_sta=1\n";
+}
 
 # Levels (minimum value for logged events):
 #  0 = verbose debugging
@@ -99,9 +103,27 @@ if ($country) {
 my $hw_mode = $config->returnValue('mode');
 if ( $hw_mode eq 'n' ) {
     print "hw_mode=g\n";
-    print "ieee80211n=1\n"
+    print "ieee80211n=1\n";
+} elsif ( $hw_mode eq 'ac' ) {
+    print "hw_mode=a\n";
+    print "ieee80211n=1\n";
+    #print "ieee80211d=1\n";	# Already set a few lines ago
+    print "ieee80211h=1\n";
+    print "ieee80211ac=1\n";
+    # ieee80211w: Whether management frame protection (MFP) is enabled
+    # 0 = disabled (default)
+    # 1 = optional
+    # 2 = required
+    #print "ieee80211w=1\n";
 } else {
     print "hw_mode=$hw_mode\n";
+}
+
+my @hostapd_options = $config->returnValues("hostapd-option");
+if (@hostapd_options > 0) {
+    foreach my $line (@hostapd_options) {
+        print "$line\n";
+    }
 }
 
 print "dump_file=/tmp/hostapd.$wlan\n";
@@ -192,6 +214,46 @@ if ( $config->exists('wep') ) {
     # Open system
     print "auth_algs=1\n";
 }
+
+# uncondifional further settings
+print "tx_queue_data3_aifs=7\n";
+print "tx_queue_data3_cwmin=15\n";
+print "tx_queue_data3_cwmax=1023\n";
+print "tx_queue_data3_burst=0\n";
+print "tx_queue_data2_aifs=3\n";
+print "tx_queue_data2_cwmin=15\n";
+print "tx_queue_data2_cwmax=63\n";
+print "tx_queue_data2_burst=0\n";
+print "tx_queue_data1_aifs=1\n";
+print "tx_queue_data1_cwmin=7\n";
+print "tx_queue_data1_cwmax=15\n";
+print "tx_queue_data1_burst=3.0\n";
+print "tx_queue_data0_aifs=1\n";
+print "tx_queue_data0_cwmin=3\n";
+print "tx_queue_data0_cwmax=7\n";
+print "tx_queue_data0_burst=1.5\n";
+print "wmm_enabled=1\n";
+print "uapsd_advertisement_enabled=1\n";
+print "wmm_ac_bk_cwmin=4\n";
+print "wmm_ac_bk_cwmax=10\n";
+print "wmm_ac_bk_aifs=7\n";
+print "wmm_ac_bk_txop_limit=0\n";
+print "wmm_ac_bk_acm=0\n";
+print "wmm_ac_be_aifs=3\n";
+print "wmm_ac_be_cwmin=4\n";
+print "wmm_ac_be_cwmax=10\n";
+print "wmm_ac_be_txop_limit=0\n";
+print "wmm_ac_be_acm=0\n";
+print "wmm_ac_vi_aifs=2\n";
+print "wmm_ac_vi_cwmin=3\n";
+print "wmm_ac_vi_cwmax=4\n";
+print "wmm_ac_vi_txop_limit=94\n";
+print "wmm_ac_vi_acm=0\n";
+print "wmm_ac_vo_aifs=2\n";
+print "wmm_ac_vo_cwmin=2\n";
+print "wmm_ac_vo_cwmax=3\n";
+print "wmm_ac_vo_txop_limit=47\n";
+print "wmm_ac_vo_acm=0\n";
 
 select STDOUT;
 close $cfg;

--- a/templates-cfg/interfaces/wireless/node.tag/channel/node.def
+++ b/templates-cfg/interfaces/wireless/node.tag/channel/node.def
@@ -1,9 +1,10 @@
 type: u32
 help: Wireless radio channel
-syntax:expression: ( $VAR(@) >= 1 && $VAR(@) <= 165 ) \
-        ; "Channel must be between 1 and 165"
+syntax:expression: ( $VAR(@) >= 0 && $VAR(@) <= 165 ) \
+        ; "Channel must be between 0 and 165"
+	; "Channel 0 means acs auto channel selection (needed for DFS)"
 
 commit:expression: exec "/opt/vyatta/sbin/wireless-config.pl --dev=$VAR(../@) --check-chan $VAR(@)"
 
 val_help:<1-14>; 2.4Ghz (802.11 b/g/n) Channel
-val_help:<34-165>; 5Ghz (802.11 a/h/j/n) Channel
+val_help:<0,34-165>; 5Ghz (802.11 a/h/j/n) Channel

--- a/templates-cfg/interfaces/wireless/node.tag/country/node.def
+++ b/templates-cfg/interfaces/wireless/node.tag/country/node.def
@@ -1,6 +1,6 @@
 type: txt
-help: Regulatory domain (optional)
+help: Regulatory domain (mandatory)
 syntax:expression: pattern $VAR(@) "^[A-Z][A-Z]$" ; "Invalid country code"
 # give partial list of obvious values
-allowed: echo "US EU JP"
+allowed: echo "US EU JP DE UK ..."
 val_help:<code>; Country code (ISO/IEC 3166-1). 

--- a/templates-cfg/interfaces/wireless/node.tag/debug/node.def
+++ b/templates-cfg/interfaces/wireless/node.tag/debug/node.def
@@ -1,0 +1,5 @@
+type: bool
+help: Enable hostapd logging to syslog (logger_syslog_level=2)
+# give partial list of obvious values
+allowed: echo "enable"
+val_help: enable; Enable hostapd logger

--- a/templates-cfg/interfaces/wireless/node.tag/debug/node.def
+++ b/templates-cfg/interfaces/wireless/node.tag/debug/node.def
@@ -1,0 +1,5 @@
+type: txt
+help: Enable hostapd logging to syslog (logger_syslog_level=2)
+# give partial list of obvious values
+allowed: echo "enable"
+val_help: enable; Enable hostapd logger

--- a/templates-cfg/interfaces/wireless/node.tag/hostapd-option/node.def
+++ b/templates-cfg/interfaces/wireless/node.tag/hostapd-option/node.def
@@ -1,0 +1,3 @@
+multi:
+type: txt
+help: Additional hostapd options

--- a/templates-cfg/interfaces/wireless/node.tag/mode/node.def
+++ b/templates-cfg/interfaces/wireless/node.tag/mode/node.def
@@ -1,9 +1,10 @@
 type: txt
 help: Wireless radio mode
 default: "g"
-allowed: echo "a b g n"
-syntax:expression: $VAR(@) in "a", "b", "g", "n" ; "mode must be a, b, g or n"
+allowed: echo "a b g n ac"
+syntax:expression: $VAR(@) in "a", "b", "g", "n", "ac" ; "mode must be a, b, g, n or ac"
 val_help:a; 802.11a - 54 Mbits/sec
 val_help:b; 802.11b - 11 Mbits/sec
 val_help:g; 802.11g - 54 Mbits/sec (default)
 val_help:n; 802.11n - 600 Mbits/sec
+val_help:ac; 802.11ac


### PR DESCRIPTION
This is a minimal set of proposed alterations to the vyatta-wireless package in order to make 5GHz access points configurable from CLI. It also allows configuring multiple wireless devices for use as multi-band access points. It as well allows to bridge those devices.